### PR TITLE
chore: update project name and copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Takeshi Kishi
+Copyright (c) 2025-2026 Takeshi Kishi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pict-mcp
+# PictMCP
 
 Pairwise Independent Combinatorial Testings for MCP
 
@@ -22,8 +22,8 @@ Pairwise Independent Combinatorial Testings for MCP
 In your terminal
 
 ```sh
-git clone https://github.com/takeyaqa/pict-mcp.git
-cd pict-mcp
+git clone https://github.com/takeyaqa/PictMCP.git
+cd PictMCP
 pnpm install
 pnpm build
 ```
@@ -33,10 +33,10 @@ In your MCP client
 ```json
 {
   "mcpServers": {
-      "pict-mcp": {
+      "PictMCP": {
           "command": "node",
           "args": [
-            "/ABSOLUTE/PATH/TO/PARENT/FOLDER/pict-mcp/dist/index.js"
+            "/ABSOLUTE/PATH/TO/PARENT/FOLDER/PictMCP/dist/index.js"
           ]
       }
   }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,24 @@
 {
-  "name": "pict-mcp",
+  "name": "pictmcp",
   "version": "0.1.0-preview",
-  "type": "module",
   "description": "Pairwise Independent Combinatorial Testings for MCP",
+  "keywords": [],
+  "homepage": "https://github.com/takeyaqa/PictMCP#readme",
+  "bugs": {
+    "url": "https://github.com/takeyaqa/PictMCP/issues"
+  },
+  "license": "MIT",
+  "author": "Takeshi Kishi",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
   "bin": {
-    "pict-mcp": "./dist/index.js"
+    "pictmcp": "./dist/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/takeyaqa/PictMCP.git"
   },
   "scripts": {
     "build": "tsc && chmod 755 dist/index.js",
@@ -14,13 +28,6 @@
     "format": "prettier --check .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "files": [
-    "dist"
-  ],
-  "keywords": [],
-  "author": "Takeshi Kishi",
-  "license": "MIT",
-  "repository": "takeyaqa/pict-mcp",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@takeyaqa/pict-wasm": "3.7.4-wasm.11",
@@ -34,5 +41,17 @@
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.33.1"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=22 <23"
+    },
+    "packageManager": [
+      {
+        "name": "pnpm",
+        "version": ">=10 <11"
+      }
+    ]
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { PictRunner } from '@takeyaqa/pict-wasm'
 
 // Create server instance
 const server = new McpServer({
-  name: 'pict-mcp',
+  name: 'PictMCP',
   description: 'Pairwise Independent Combinatorial Testings for MCP',
   version: '0.1.0',
   capabilities: {
@@ -52,7 +52,7 @@ server.tool(
 async function main() {
   const transport = new StdioServerTransport()
   await server.connect(transport)
-  console.error('Pict MCP Server running on stdio')
+  console.error('PictMCP Server running on stdio')
 }
 
 main().catch((error: unknown) => {


### PR DESCRIPTION
This pull request updates the project to consistently use the `PictMCP` naming convention across the codebase and documentation, and improves the metadata in `package.json` for better clarity and package management. The most important changes are as follows:

**Project Naming Consistency:**

* Updated all references from `pict-mcp` to `PictMCP` or `pictmcp` in documentation (`README.md`), code (`src/index.ts`), and configuration files (`package.json`). This includes repository URLs, directory names, and command names. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R26) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R39) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R21) [[5]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L8-R8)

**Package Metadata Improvements:**

* Enhanced `package.json` with additional metadata fields such as `homepage`, `bugs`, `author`, `license`, and `repository`, and moved the `files` and `keywords` fields for better package clarity. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R21) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-L23)
* Updated the `bin` field in `package.json` to use `pictmcp` instead of `pict-mcp` for the CLI command.

**Development Environment Specification:**

* Added a `devEngines` section to `package.json` to specify the required Node.js and `pnpm` versions for development.

**Legal and Copyright:**

* Updated the copyright year in the `LICENSE` file to reflect the new range (2025–2026).