### PR TITLE
ci: modify workflow triggers to only run on pull requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,8 +1,6 @@
 name: check
 on:
-  push:
-    branches-ignore: [main]
-  workflow_dispatch:
+  pull_request:
 
 env:
   PNPM_VERSION: 10
@@ -47,4 +45,4 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install
-      - run: pnpm run typecheck 
+      - run: pnpm run typecheck


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow trigger to improve CI/CD behavior. The workflow will now run on pull requests rather than on pushes to non-main branches.

Workflow configuration:

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L3-R3): Changed the workflow trigger from running on pushes (excluding `main`) to running on `pull_request` events.