### PR TITLE
chore: update dependabot configuration for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,20 +4,26 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 1
+    open-pull-requests-limit: 10
     commit-message:
       prefix: "build"
       include: "scope"
+    groups:
+      eslint:
+        patterns:
+          - "@eslint/*"
+          - "eslint"
+          - "eslint-config-prettier"
+          - "typescript-eslint"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 1
+    open-pull-requests-limit: 10
     commit-message:
       prefix: "ci"
-      include: "scope"
-  - package-ecosystem: "devcontainers"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore"
       include: "scope"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to improve how dependency updates are managed and grouped, and removes support for devcontainer updates. The most important changes are:

Dependabot update management improvements:
* Added a `cooldown` period of 1 day and set a limit of 10 open pull requests for both npm and GitHub Actions updates in `.github/dependabot.yml`, helping to control the frequency and volume of PRs.

Dependency grouping:
* Introduced a new `groups` section for npm updates, specifically grouping all ESLint-related dependencies under an `eslint` group to make updates more organized and easier to review.

Configuration cleanup:
* Removed the configuration for devcontainer updates, so Dependabot will no longer create PRs for changes in devcontainer files.