### PR TITLE
build: update Node.js version to 24

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,32 +1,14 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
 {
-	"name": "Node.js & TypeScript",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+  "name": "Node.js & TypeScript",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24",
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	"features": {
-		"ghcr.io/devcontainers/features/common-utils:2": {}
-	},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
-
-	// Configure tool-specific properties.
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"dbaeumer.vscode-eslint",
-				"esbenp.prettier-vscode",
-				"github.vscode-github-actions"
-			]
-		}
-	}
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "github.vscode-github-actions"
+      ]
+    }
+  }
 }

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,7 +4,7 @@ on:
 
 env:
   PNPM_VERSION: 10
-  NODE_VERSION: 22
+  NODE_VERSION: 24
 
 jobs:
   lint:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": ">=22 <23"
+      "version": ">=24 <25"
     },
     "packageManager": [
       {


### PR DESCRIPTION
This pull request updates the project's Node.js environment to version 24, ensuring consistency across the development container, CI workflow, and engine requirements. The changes remove older configuration options and references to previous Node.js versions.

**Node.js version upgrade:**
* Updated the dev container base image in `.devcontainer/devcontainer.json` from Node.js 22 to Node.js 24, and removed unused configuration options and comments. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L1-L19) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L29-L31)
* Updated the Node.js version in the GitHub Actions workflow (`.github/workflows/check.yml`) from 22 to 24.
* Updated the Node.js engine requirement in `package.json` to `>=24 <25`.