### PR TITLE
ci: update pnpm/action-setup to v4.2.0 in workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to pin the `pnpm/action-setup` action to a specific commit hash instead of using the version tag. This increases security and reliability by ensuring that the workflow always uses the exact same version of the action.

Workflow improvements:

* Updated `pnpm/action-setup` in `.github/workflows/check.yml` to use a specific commit hash (`41ff72655975bd51cab0327fa583b6e92b6d3061`) instead of the general `v4` tag, ensuring consistent and secure action usage. [[1]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L14-R14) [[2]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L27-R27) [[3]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L40-R40)