### PR TITLE
chore: update dependabot configuration to group eslint and prettier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,19 +11,21 @@ updates:
       prefix: "build"
       include: "scope"
     groups:
-      eslint:
+      eslint-and-prettier:
         patterns:
           - "@eslint/*"
           - "eslint"
           - "eslint-config-prettier"
+          - "prettier"
           - "typescript-eslint"
+    ignore:
+      - dependency-name: "@takeyaqa/pict-wasm"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 1
-    open-pull-requests-limit: 10
     commit-message:
       prefix: "ci"
       include: "scope"


### PR DESCRIPTION
This pull request updates the Dependabot configuration to improve how dependency updates are grouped and managed. The main change is to group ESLint and Prettier-related dependencies together and to ignore updates for a specific dependency.

**Dependabot configuration improvements:**

* Renamed the `eslint` group to `eslint-and-prettier` and added `prettier` and `eslint-config-prettier` to the group patterns to ensure ESLint and Prettier-related updates are bundled together.
* Added an ignore rule for the `@takeyaqa/pict-wasm` dependency to prevent Dependabot from creating update PRs for it.