### PR TITLE
docs: add SECURITY.md for reporting security issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Reporting Security Issues
+
+The PictMCP team and community take security bugs in PictMCP seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/takeyaqa/PictMCP/security/advisories/new) tab.
+
+The PictMCP team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party modules to the person or team maintaining the module. You can also report a vulnerability through the [npm contact form](https://www.npmjs.com/support) by selecting "I'm reporting a security vulnerability".


### PR DESCRIPTION
This pull request adds a new section to the project's security documentation, outlining how to report security issues and what to expect from the team during the disclosure process.

Security policy documentation:

* Added a "Reporting Security Issues" section to `SECURITY.md`, providing clear instructions for responsible disclosure, including using GitHub's "Report a Vulnerability" feature and guidance for third-party modules.