### PR TITLE
chore: add default formatter setting for VSCode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
 
   "customizations": {
     "vscode": {
+      "settings": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+      },
       "extensions": [
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",


### PR DESCRIPTION
This pull request makes a small configuration improvement to the development container setup by specifying a default code formatter for VS Code. This will help ensure consistent code formatting for all contributors using the dev container.

* Set `editor.defaultFormatter` to `esbenp.prettier-vscode` in `.devcontainer/devcontainer.json` to standardize code formatting in VS Code.