### PR TITLE
build: add minimumReleaseAgeExclude

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - "@takeyaqa/pict-wasm"
 trustPolicy: no-downgrade


### PR DESCRIPTION
This pull request introduces a configuration update to the workspace release process. The main change is the exclusion of the `@takeyaqa/pict-wasm` package from the minimum release age requirement.

Release process configuration:

* Updated `pnpm-workspace.yaml` to exclude the `@takeyaqa/pict-wasm` package from the `minimumReleaseAge` restriction, allowing it to be released without waiting for the minimum age.