### PR TITLE
ci: add GitHub Actions workflow for publishing to MCP Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish to MCP Registry
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        with:
+          version: 10
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - name: Update npm to latest version
+        run: npm install -g npm@latest
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build package
+        run: pnpm run build
+      - name: Publish to npm registry
+        run: pnpm publish
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate publishing the package to the MCP Registry upon release. The workflow handles building, publishing to npm, and then authenticating and publishing to the MCP Registry.

**New CI/CD workflow for publishing:**

* Added `.github/workflows/publish.yml` to automate publishing on release, including steps for installing dependencies, building the package, publishing to npm, and publishing to the MCP Registry using OIDC authentication.