### PR TITLE
ci: update publish command to skip git checks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build package
         run: pnpm run build
       - name: Publish to npm registry
-        run: pnpm publish
+        run: pnpm publish --no-git-checks
       - name: Install mcp-publisher
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher


### PR DESCRIPTION
This pull request makes a small change to the npm publish step in the GitHub Actions workflow. The change ensures that publishing to npm does not require git checks, which can help avoid issues in CI environments.

* Updated the `pnpm publish` command in `.github/workflows/publish.yml` to include the `--no-git-checks` flag.