### PR TITLE
chore: rename lint and format commands

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,19 @@ env:
   NODE_VERSION: 24
 
 jobs:
+  formatcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm run fmt:check
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -20,19 +33,6 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: pnpm run lint
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-      - run: pnpm install
-      - run: pnpm run format
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+env:
+  PNPM_VERSION: 10
+  NODE_VERSION: 24
+
 permissions:
   id-token: write # Required for OIDC
   contents: read
@@ -16,10 +20,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
-          version: 10
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - name: Update npm to latest version

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Pairwise Independent Combinatorial Testings for MCP
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) (v22 or higher)
+- [Node.js](https://nodejs.org/) (v24 or higher)
 - [pnpm](https://pnpm.io/) (v10 or higher)
 
 ### Commands

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
   "scripts": {
     "build": "tsc && chmod 755 dist/index.js",
     "clean": "rm -rf dist",
-    "typecheck": "tsc --noEmit",
+    "fmt": "prettier --write .",
+    "fmt:check": "prettier --check .",
     "lint": "eslint .",
-    "format": "prettier --check .",
+    "lint:fix": "eslint --fix .",
+    "typecheck": "tsc --noEmit",
     "test": "vitest",
-    "test:no-watch": "vitest run"
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",


### PR DESCRIPTION
This pull request updates the project's Node.js and pnpm version requirements, improves the npm scripts for formatting and linting, and reorganizes the GitHub Actions workflows for better clarity and consistency. The most important changes are outlined below.

**Workflow and Environment Configuration:**

* Updated Node.js version requirement from v22 to v24 in the documentation and CI workflows, and introduced environment variables for `NODE_VERSION` and `PNPM_VERSION` in `.github/workflows/publish.yml` for easier version management. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R17) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R7-R10) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L19-R26)

**GitHub Actions Workflow Improvements:**

* Swapped the order and naming of `lint` and `format` jobs in `.github/workflows/check.yml` to use `fmt:check` for formatting and `lint` for linting, improving clarity and aligning with updated scripts. [[1]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L10-R10) [[2]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L22-R23) [[3]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L35-R35)

**NPM Scripts Enhancements:**

* Added new scripts: `fmt` for formatting, `fmt:check` for format checking, and `lint:fix` for auto-fixing lint issues; renamed `test:no-watch` to `test:run` for clarity and consistency in `package.json`.