### PR TITLE
build(deps): update @takeyaqa/pict-wasm to version 3.7.4-wasm.12 and refactor PictRunner initialization in index.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",
-    "@takeyaqa/pict-wasm": "3.7.4-wasm.11",
+    "@takeyaqa/pict-wasm": "3.7.4-wasm.12",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.25.2
         version: 1.25.3(hono@4.11.4)(zod@4.3.6)
       '@takeyaqa/pict-wasm':
-        specifier: 3.7.4-wasm.11
-        version: 3.7.4-wasm.11
+        specifier: 3.7.4-wasm.12
+        version: 3.7.4-wasm.12
       zod:
         specifier: ^4.3.5
         version: 4.3.6
@@ -424,8 +424,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@takeyaqa/pict-wasm@3.7.4-wasm.11':
-    resolution: {integrity: sha512-k+U+UzmKnvYxSdJs9m+DddyQmLO+Fz8tzjaJvwDS4xDLJKsNXxzd1RneoZGye7Fx+PEnDZEXlckMBj2P7IF5cQ==}
+  '@takeyaqa/pict-wasm@3.7.4-wasm.12':
+    resolution: {integrity: sha512-vf9cbRPy8rqJgYPqzX3Jav3JhJfhCOeVq7q1eoGwuHpjxPW6QyU/w4D6q6rFsTcJxjoDi9Jp8vS1GcUgsDtpRQ==}
+    engines: {node: '>=22'}
 
   '@tsconfig/node-ts@23.6.2':
     resolution: {integrity: sha512-WcU3KR3tHB8XMotRBpUEGfPLT3W0gAhrHcTxU7mNQ4N1+fwF3LbjpWP07TuhZtN5ehK3bcK/R4Zzqp7Pqd7Nqg==}
@@ -1593,7 +1594,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@takeyaqa/pict-wasm@3.7.4-wasm.11': {}
+  '@takeyaqa/pict-wasm@3.7.4-wasm.12': {}
 
   '@tsconfig/node-ts@23.6.2': {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,13 +26,14 @@ server.registerTool(
     },
   },
   async ({ parameters, constraints }) => {
-    const pictRunner = new PictRunner();
-    await pictRunner.init();
+    const pictRunner = await PictRunner.create();
     const output = pictRunner.run(parameters, { constraintsText: constraints });
-    const formattedOutput = output.body.map((row) =>
+    const formattedOutput = output.result.body.map((row) =>
       row.map((cell) => cell.trim()).join(", "),
     );
-    const formattedHeader = output.header.map((cell) => cell.trim()).join(", ");
+    const formattedHeader = output.result.header
+      .map((cell) => cell.trim())
+      .join(", ");
     const formattedBody = formattedOutput.join("\n");
     const formattedOutputText = `Header: ${formattedHeader}\nBody:\n${formattedBody}`;
 


### PR DESCRIPTION
This pull request updates the `@takeyaqa/pict-wasm` dependency to version `3.7.4-wasm.12` and refactors the usage of the `PictRunner` class to accommodate breaking changes in the new version. The main changes ensure compatibility with the updated package and improve how the output from `PictRunner` is accessed and formatted.

**Dependency update:**

* Upgraded `@takeyaqa/pict-wasm` from version `3.7.4-wasm.11` to `3.7.4-wasm.12` in `package.json` and updated all relevant entries in `pnpm-lock.yaml`. The new version now requires Node.js 22 or higher. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L48-R48) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15-R16) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL427-R429) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1596-R1597)

**Code refactor for compatibility:**

* Refactored the instantiation of `PictRunner` in `src/index.ts` to use the new asynchronous `PictRunner.create()` method instead of direct construction and initialization.
* Updated how the output from `PictRunner.run()` is accessed: replaced references to `output.body` and `output.header` with `output.result.body` and `output.result.header` to match the new API structure.