### PR TITLE
refactor: implement PictMCPServer class and update server initialization in index.ts

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -3,15 +3,17 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import packageJson from "../package.json" with { type: "json" };
 import serverJson from "../server.json" with { type: "json" };
-import { server } from "./index.js";
+import { PictMCPServer } from "./server.js";
 
 describe("PictMCP Server", () => {
+  let server: PictMCPServer;
   let client: Client;
 
   beforeEach(async () => {
     const [clientTransport, serverTransport] =
       InMemoryTransport.createLinkedPair();
 
+    server = new PictMCPServer();
     client = new Client({ name: "test-client", version: "1.0.0" });
 
     await server.connect(serverTransport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,57 +1,8 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { z } from "zod";
-import { PictRunner } from "@takeyaqa/pict-wasm";
-
-// Create server instance
-const server = new McpServer({
-  name: "PictMCP",
-  version: "0.2.0",
-});
-
-// Register pict tools
-server.registerTool(
-  "generate-test-cases",
-  {
-    description: "Generates test cases using pairwise combination algorithm",
-    inputSchema: {
-      parameters: z
-        .object({ name: z.string(), values: z.string() })
-        .array()
-        .describe("Parameters for the test case generation"),
-      constraints: z
-        .string()
-        .optional()
-        .describe("Constraints for the test case generation"),
-    },
-  },
-  async ({ parameters, constraints }) => {
-    const pictRunner = await PictRunner.create();
-    const output = pictRunner.run(parameters, { constraintsText: constraints });
-    const formattedOutput = output.result.body.map((row) =>
-      row.map((cell) => cell.trim()).join(", "),
-    );
-    const formattedHeader = output.result.header
-      .map((cell) => cell.trim())
-      .join(", ");
-    const formattedBody = formattedOutput.join("\n");
-    const formattedOutputText = `Header: ${formattedHeader}\nBody:\n${formattedBody}`;
-
-    return {
-      content: [
-        {
-          type: "text",
-          text: formattedOutputText,
-        },
-      ],
-    };
-  },
-);
-
-// export for testing purposes
-export { server };
+import { PictMCPServer } from "./server.js";
 
 async function main() {
+  const server = new PictMCPServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("PictMCP Server running on stdio");

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,88 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { LoggingMessageNotification } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { PictRunner } from "@takeyaqa/pict-wasm";
+
+export class PictMCPServer {
+  private server: McpServer;
+
+  constructor() {
+    this.server = new McpServer({
+      name: "PictMCP",
+      version: "0.2.0",
+    });
+    // Register pict tools
+    this.server.registerTool(
+      "generate-test-cases",
+      {
+        description:
+          "Generates test cases using pairwise combination algorithm",
+        inputSchema: {
+          parameters: z
+            .object({ name: z.string(), values: z.string() })
+            .array()
+            .describe("Parameters for the test case generation"),
+          constraints: z
+            .string()
+            .optional()
+            .describe("Constraints for the test case generation"),
+        },
+      },
+      async ({ parameters, constraints }) => {
+        const pictRunner = await PictRunner.create();
+        const output = pictRunner.run(parameters, {
+          constraintsText: constraints,
+        });
+        const formattedOutput = output.result.body.map((row) =>
+          row.map((cell) => cell.trim()).join(", "),
+        );
+        const formattedHeader = output.result.header
+          .map((cell) => cell.trim())
+          .join(", ");
+        const formattedBody = formattedOutput.join("\n");
+        const formattedOutputText = `Header: ${formattedHeader}\nBody:\n${formattedBody}`;
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: formattedOutputText,
+            },
+          ],
+        };
+      },
+    );
+  }
+
+  connect(transport: Transport): Promise<void> {
+    return this.server.connect(transport);
+  }
+
+  close(): Promise<void> {
+    return this.server.close();
+  }
+
+  isConnected(): boolean {
+    return this.server.isConnected();
+  }
+
+  sendLoggingMessage(
+    params: LoggingMessageNotification["params"],
+    sessionId?: string,
+  ): Promise<void> {
+    return this.server.sendLoggingMessage(params, sessionId);
+  }
+
+  sendResourceListChanged(): void {
+    this.server.sendResourceListChanged();
+  }
+
+  sendToolListChanged(): void {
+    this.server.sendToolListChanged();
+  }
+
+  sendPromptListChanged(): void {
+    this.server.sendPromptListChanged();
+  }
+}


### PR DESCRIPTION
This pull request refactors the server initialization and tool registration logic by moving it from `src/index.ts` to a new `PictMCPServer` class in `src/server.ts`. This change improves code organization, testability, and maintainability by encapsulating server functionality within a dedicated class. The test and entrypoint files are updated to use this new class.

**Server architecture and encapsulation:**

* Introduced a new `PictMCPServer` class in `src/server.ts` that encapsulates the server setup, tool registration, and utility methods such as `connect`, `close`, and various notification senders.
* Refactored `src/index.ts` to use `PictMCPServer` instead of directly instantiating and configuring the server, simplifying the entrypoint and improving separation of concerns.

**Testing improvements:**

* Updated the test setup in `src/index.spec.ts` to instantiate and use the new `PictMCPServer` class, ensuring tests reflect the new server structure.