### PR TITLE
chore: update version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pictmcp",
   "mcpName": "io.github.takeyaqa/PictMCP",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "MCP (Model Context Protocol) server that provides pairwise combinatorial testing capabilities to AI assistants.",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.takeyaqa/PictMCP",
   "title": "PictMCP",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Provides pairwise combinatorial testing capabilities to AI assistants.",
   "websiteUrl": "https://github.com/takeyaqa/PictMCP#readme",
   "repository": {
@@ -25,7 +25,7 @@
     {
       "registryType": "npm",
       "identifier": "pictmcp",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ export class PictMcpServer extends McpServer {
     super({
       name: "io.github.takeyaqa/PictMCP",
       title: "PictMCP",
-      version: "0.2.0",
+      version: "0.3.0",
       description:
         "Provides pairwise combinatorial testing capabilities to AI assistants.",
       websiteUrl: "https://github.com/takeyaqa/PictMCP#readme",


### PR DESCRIPTION
This pull request updates the version of the PictMCP server from 0.2.0 to 0.3.0 across the project to ensure consistency and reflect the latest changes.

Version update:

* Bumped the version from 0.2.0 to 0.3.0 in `package.json` to indicate a new release.
* Updated the version field to 0.3.0 in `server.json` for both the main version and the npm registry identifier. [[1]](diffhunk://#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429L5-R5) [[2]](diffhunk://#diff-a49a8fd223e4838c13a52213b7ed14b3c5aa03077d9d94b621b27484875be429L28-R28)
* Changed the version to 0.3.0 in the `PictMcpServer` class constructor in `src/server.ts`.