### PR TITLE
fix: add shebang to index.ts for executable script

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { PictMcpServer } from "./server.js";
 


### PR DESCRIPTION
This pull request adds a shebang line to the top of the `src/index.ts` file, enabling it to be run directly as a CLI script. This is a small but important change for improving developer experience and script usability.