### PR TITLE
refactor: remove unnecessary build step from CI workflow and update import path in tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install
-      - run: pnpm run build
       - run: pnpm run fmt:check
   lint:
     runs-on: ubuntu-latest
@@ -33,7 +32,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install
-      - run: pnpm run build
       - run: pnpm run lint
   typecheck:
     runs-on: ubuntu-latest
@@ -47,7 +45,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install
-      - run: pnpm run build
       - run: pnpm run typecheck
   test:
     runs-on: ubuntu-latest
@@ -61,5 +58,4 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install
-      - run: pnpm run build
       - run: pnpm run test

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -4,7 +4,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import packageJson from "../package.json" with { type: "json" };
 import serverJson from "../server.json" with { type: "json" };
-import { PictMcpServer } from "../dist/server.js";
+import { PictMcpServer } from "../src/server.js";
 
 describe("PictMcpServer", () => {
   let server: PictMcpServer;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
   ],
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "declaration": true
+    "outDir": "dist"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.spec.ts"]


### PR DESCRIPTION
This pull request primarily updates the workflow configuration and test setup. The most significant changes are the removal of unnecessary build steps from CI workflows and an update to the test import path.

**Continuous Integration Workflow Simplification:**

* Removed the `pnpm run build` step from the `fmt:check`, `lint`, `typecheck`, and `test` jobs in `.github/workflows/check.yml` to streamline the CI process and avoid redundant builds. [[1]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L22) [[2]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L36) [[3]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L50) [[4]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L64)

**Test Import Path Update:**

* Changed the import of `PictMcpServer` in `tests/e2e.spec.ts` from `../dist/server.js` to `../src/server.js`, ensuring tests run against the source code rather than the built output.