### PR TITLE
refactor: replace PictMcpServer class with createPictMcpServer function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { PictMcpServer } from "./server.js";
+import { createPictMcpServer } from "./server.js";
 
 async function main() {
-  const server = new PictMcpServer();
+  const server = createPictMcpServer();
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("PictMCP Server running on stdio");

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,110 +2,106 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { PictRunner } from "@takeyaqa/pict-wasm";
 
-export class PictMcpServer extends McpServer {
-  constructor() {
-    super({
-      name: "io.github.takeyaqa/PictMCP",
-      title: "PictMCP",
-      version: "0.3.1",
-      description:
-        "Provides pairwise combinatorial testing capabilities to AI assistants.",
-      websiteUrl: "https://github.com/takeyaqa/PictMCP#readme",
-      icons: [
-        {
-          src: "https://raw.githubusercontent.com/takeyaqa/PictMCP/main/assets/PictMCP_icon@64x64.png",
-          mimeType: "image/png",
-          sizes: ["64x64"],
-        },
-        {
-          src: "https://raw.githubusercontent.com/takeyaqa/PictMCP/main/assets/PictMCP_icon.svg",
-          mimeType: "image/svg+xml",
-          sizes: ["any"],
-        },
-      ],
-    });
-
-    // Register pict tools
-    this.registerTool(
-      "generate-test-cases",
+export function createPictMcpServer() {
+  const server = new McpServer({
+    name: "io.github.takeyaqa/PictMCP",
+    title: "PictMCP",
+    version: "0.3.1",
+    description:
+      "Provides pairwise combinatorial testing capabilities to AI assistants.",
+    websiteUrl: "https://github.com/takeyaqa/PictMCP#readme",
+    icons: [
       {
-        title: "Generate test cases",
-        description:
-          "Executes PICT with the given parameters and options to generate test cases.",
-        inputSchema: {
-          parameters: z
-            .object({
-              name: z.string().describe("The name of the parameter."),
-              values: z
-                .string()
-                .describe(
-                  "A comma-separated string of possible values for this parameter.",
-                ),
-            })
-            .array()
-            .describe(
-              "Represents a parameter definition for PICT test case generation.",
-            ),
-          constraintsText: z
-            .string()
-            .optional()
-            .describe(
-              "PICT constraint expressions to filter invalid combinations.",
-            ),
-        },
-        outputSchema: {
-          result: z
-            .object({
-              header: z
-                .string()
-                .array()
-                .describe(
-                  "An array of parameter names representing the column headers.",
-                ),
-              body: z
-                .string()
-                .array()
-                .array()
-                .describe(
-                  "A two-dimensional array where each inner array represents a test case, with values corresponding to the header columns.",
-                ),
-            })
-            .describe(
-              "Represents the parsed result of PICT test case generation.",
-            ),
-          modelFile: z
-            .string()
-            .describe(
-              "The complete model file content that was passed to PICT.",
-            ),
-          message: z
-            .string()
-            .optional()
-            .describe(
-              "Optional message output from PICT, typically containing information.",
-            ),
-        },
+        src: "https://raw.githubusercontent.com/takeyaqa/PictMCP/main/assets/PictMCP_icon@64x64.png",
+        mimeType: "image/png",
+        sizes: ["64x64"],
       },
-      async ({ parameters, constraintsText }) => {
-        const pictRunner = await PictRunner.create();
-        const output = pictRunner.run(parameters, {
-          constraintsText,
-        });
+      {
+        src: "https://raw.githubusercontent.com/takeyaqa/PictMCP/main/assets/PictMCP_icon.svg",
+        mimeType: "image/svg+xml",
+        sizes: ["any"],
+      },
+    ],
+  });
 
-        return {
-          structuredContent: {
-            result: output.result,
-            modelFile: output.modelFile,
-            message: output.message,
-          },
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(output),
-            },
-          ],
-        };
+  server.registerTool(
+    "generate-test-cases",
+    {
+      title: "Generate test cases",
+      description:
+        "Executes PICT with the given parameters and options to generate test cases.",
+      inputSchema: {
+        parameters: z
+          .object({
+            name: z.string().describe("The name of the parameter."),
+            values: z
+              .string()
+              .describe(
+                "A comma-separated string of possible values for this parameter.",
+              ),
+          })
+          .array()
+          .describe(
+            "Represents a parameter definition for PICT test case generation.",
+          ),
+        constraintsText: z
+          .string()
+          .optional()
+          .describe(
+            "PICT constraint expressions to filter invalid combinations.",
+          ),
       },
-    );
-  }
+      outputSchema: {
+        result: z
+          .object({
+            header: z
+              .string()
+              .array()
+              .describe(
+                "An array of parameter names representing the column headers.",
+              ),
+            body: z
+              .string()
+              .array()
+              .array()
+              .describe(
+                "A two-dimensional array where each inner array represents a test case, with values corresponding to the header columns.",
+              ),
+          })
+          .describe(
+            "Represents the parsed result of PICT test case generation.",
+          ),
+        modelFile: z
+          .string()
+          .describe("The complete model file content that was passed to PICT."),
+        message: z
+          .string()
+          .optional()
+          .describe(
+            "Optional message output from PICT, typically containing information.",
+          ),
+      },
+    },
+    async ({ parameters, constraintsText }) => {
+      const pictRunner = await PictRunner.create();
+      const output = pictRunner.run(parameters, {
+        constraintsText,
+      });
+
+      return {
+        structuredContent: {
+          result: output.result,
+          modelFile: output.modelFile,
+          message: output.message,
+        },
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(output),
+          },
+        ],
+      };
+    },
+  );
+  return server;
 }

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -1,20 +1,21 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import packageJson from "../package.json" with { type: "json" };
 import serverJson from "../server.json" with { type: "json" };
-import { PictMcpServer } from "../src/server.js";
+import { createPictMcpServer } from "../src/server.js";
 
 describe("PictMcpServer", () => {
-  let server: PictMcpServer;
+  let server: McpServer;
   let client: Client;
 
   beforeEach(async () => {
     const [clientTransport, serverTransport] =
       InMemoryTransport.createLinkedPair();
 
-    server = new PictMcpServer();
+    server = createPictMcpServer();
     client = new Client({ name: "test-client", version: "1.0.0" });
 
     await server.connect(serverTransport);


### PR DESCRIPTION
This pull request refactors the way the PictMcpServer is created and used throughout the codebase. Instead of exporting a `PictMcpServer` class, the code now exports a `createPictMcpServer` factory function that returns a configured `McpServer` instance. This change simplifies server instantiation and aligns with functional programming practices. Related updates were made to the CLI entry point and tests to use the new factory function.

**Refactor PictMcpServer to a factory function:**

* Replaced the `PictMcpServer` class with a `createPictMcpServer` function that returns a configured `McpServer` instance, and updated all usages accordingly (`src/server.ts`, `src/index.ts`, `tests/e2e.spec.ts`). [[1]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595L5-R6) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595L110-R106) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L4-R7) [[4]](diffhunk://#diff-01f5093ac81bb7c47ad2ff4bf7e4b66380a4dc4a1c10b06f3f127db8d3d55ed5R2-R18)

**Code and test updates:**

* Updated the CLI entry point (`src/index.ts`) and end-to-end tests (`tests/e2e.spec.ts`) to use the new `createPictMcpServer` function instead of instantiating the class directly. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L4-R7) [[2]](diffhunk://#diff-01f5093ac81bb7c47ad2ff4bf7e4b66380a4dc4a1c10b06f3f127db8d3d55ed5R2-R18)

**Minor formatting:**

* Cleaned up multi-line `.describe()` usage for schema fields in `src/server.ts`.