### PR TITLE
feat: add error handling for invalid input

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -118,4 +118,22 @@ IF [OS] = "macOS" THEN [Browser] <> "Edge";`,
     expect(textContent.type).toEqual("text");
     expect(JSON.parse(textContent.text)).toEqual(response.structuredContent);
   });
+
+  it("should return error for invalid constraint syntax", async () => {
+    const response = await client.callTool({
+      name: "generate-test-cases",
+      arguments: {
+        parameters: [
+          { name: "OS", values: "Windows, macOS" },
+          { name: "Browser", values: "Chrome, Firefox" },
+        ],
+        constraintsText: 'IF [OS] = "Windows" THEN [Browser] <> ;',
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    const textContent = (response.content as Array<unknown>)[0] as TextContent;
+    expect(textContent.type).toEqual("text");
+    expect(textContent.text).toContain("Input Error:");
+  });
 });


### PR DESCRIPTION
This pull request improves error handling in the `createPictMcpServer` function and adds a new test to verify that invalid constraint syntax is properly reported as an error. The main focus is on catching and returning errors from the `PictRunner` and ensuring that users receive informative error messages.

**Error handling improvements:**

* Wrapped the call to `PictRunner.run` in a `try/catch` block to catch errors, specifically handling `PictError` and returning a user-friendly error message in the response. [[1]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R86) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R105-R119)
* Updated the import statement to include `PictError` from `@takeyaqa/pict-wasm` for more specific error handling.

**Testing enhancements:**

* Added a new end-to-end test in `tests/e2e.spec.ts` to verify that invalid constraint syntax results in an error response containing an appropriate error message.