### PR TITLE
chore: simplify ESLint and Vitest configurations for test file inclusion

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,8 +7,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 export default defineConfig([
   globalIgnores(["dist"]),
   {
-    files: ["src/**/*.{js,mjs,cjs,ts,mts,cts}"],
-    ignores: ["src/**/*.spec.{js,mjs,cjs,ts,mts,cts}"],
+    files: ["src/**/*.ts"],
     plugins: { js, tseslint },
     extends: [
       "js/recommended",
@@ -22,7 +21,7 @@ export default defineConfig([
     },
   },
   {
-    files: ["{src,tests}/**/*.spec.{js,mjs,cjs,ts,mts,cts}"],
+    files: ["tests/**/*.spec.ts"],
     plugins: { js, tseslint, vitest },
     extends: ["js/recommended", "tseslint/recommended", "vitest/recommended"],
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,5 @@
     "rootDir": "src",
     "outDir": "dist"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["{src,tests}/**/*.spec.ts"],
+    include: ["./tests/**/*.spec.ts"],
   },
 });


### PR DESCRIPTION
This pull request updates the ESLint and Vitest configuration files to better target TypeScript source and test files, improving consistency and specificity in linting and testing. The main changes refine file matching patterns to focus on `.ts` files in the appropriate directories.

**Linting configuration updates:**

* Updated the ESLint config to only include TypeScript files (`.ts`) in the `src` directory and exclude test files from the main linting rules. (`eslint.config.js`, [eslint.config.jsL10-R10](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L10-R10))
* Changed the test-specific ESLint config to target only `.spec.ts` files in the `tests` directory, ensuring that test linting is applied consistently. (`eslint.config.js`, [eslint.config.jsL25-R24](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L25-R24))

**Testing configuration updates:**

* Refined the Vitest configuration to include only `.spec.ts` files within the `tests` directory, improving test discovery accuracy. (`vitest.config.ts`, [vitest.config.tsL5-R5](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92L5-R5))