### PR TITLE
chore: add Vitest extension to devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
       "extensions": [
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        "github.vscode-github-actions"
+        "github.vscode-github-actions",
+        "vitest.explorer"
       ]
     }
   }


### PR DESCRIPTION
This pull request makes a minor update to the development container configuration by adding the `vitest.explorer` extension to the list of recommended VS Code extensions. This will help developers run and explore Vitest tests more easily in their development environment.