### PR TITLE
chore: update GitHub Actions schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 1
     commit-message:


### PR DESCRIPTION
This pull request makes a small change to the Dependabot configuration by updating the schedule for GitHub Actions updates from weekly to monthly.