### PR TITLE
chore: downgrade Node.js version in devcontainer and package.json to 22

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Node.js & TypeScript",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:24",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "^22 || ^24"
+      "version": "^22"
     },
     "packageManager": [
       {


### PR DESCRIPTION
This pull request updates the development environment and engine requirements to use Node.js version 22 exclusively, removing support for Node.js 24.

Environment and engine version updates:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L3-R3): Changed the development container base image from Node.js 24 to Node.js 22.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L70-R70): Updated the `devEngines.runtime.version` field to require only Node.js 22, dropping support for Node.js 24.