### PR TITLE
build(deps): update @takeyaqa/pict-wasm to version 3.7.4-wasm.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@takeyaqa/pict-wasm": "3.7.4-wasm.15",
+    "@takeyaqa/pict-wasm": "3.7.4-wasm.17",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.27.1
         version: 1.27.1(zod@4.3.6)
       '@takeyaqa/pict-wasm':
-        specifier: 3.7.4-wasm.15
-        version: 3.7.4-wasm.15
+        specifier: 3.7.4-wasm.17
+        version: 3.7.4-wasm.17
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -424,8 +424,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@takeyaqa/pict-wasm@3.7.4-wasm.15':
-    resolution: {integrity: sha512-mJaOooFwd2CqisvoG12DE4Ld+3Vmw5Iyd0AevRlx+V/0uFehJe/EwzJzUXRG3JDQkl3wjNohfyd1yCp5ZU6g8w==}
+  '@takeyaqa/pict-wasm@3.7.4-wasm.17':
+    resolution: {integrity: sha512-hUFSaCJ2GhyKwjpsGi3p709shOT5c5o4XDkOuS4s3D/FKQkLrDyxiTVYOwqzg3NZ8XtpI3Bww2Mb7q7qSKUT5Q==}
     engines: {node: ^22 || ^24}
 
   '@tsconfig/node-ts@23.6.4':
@@ -1607,7 +1607,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@takeyaqa/pict-wasm@3.7.4-wasm.15': {}
+  '@takeyaqa/pict-wasm@3.7.4-wasm.17': {}
 
   '@tsconfig/node-ts@23.6.4': {}
 


### PR DESCRIPTION
This pull request updates the `@takeyaqa/pict-wasm` dependency from version `3.7.4-wasm.15` to `3.7.4-wasm.17` across the project. This ensures that the codebase uses the latest compatible version of this package.

Dependency update:

* Updated the `@takeyaqa/pict-wasm` dependency version in `package.json`, `pnpm-lock.yaml`, and associated package resolution and snapshot entries to `3.7.4-wasm.17`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L48-R48) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15-R16) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL427-R428) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1610-R1610)